### PR TITLE
Fix Storm header alignment

### DIFF
--- a/StormMemPoolFix/Base/MemoryBackend.cpp
+++ b/StormMemPoolFix/Base/MemoryBackend.cpp
@@ -76,7 +76,7 @@ namespace MemoryPool {
         case MemBackendType::System:
         {
             // 使用系统分配 - 添加花括号创建作用域
-            void* sysPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader),
+            void* sysPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader) + 2,
                 MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
             if (!sysPtr) return nullptr;
 

--- a/StormMemPoolFix/Base/MemorySafetyUtils.h
+++ b/StormMemPoolFix/Base/MemorySafetyUtils.h
@@ -103,7 +103,7 @@ public:
         }
 
         // 如果特殊标记
-        if (header->HeapPtr == SPECIAL_MARKER) {
+        if (header->HeapId == SPECIAL_MARKER) {
             return true;
         }
 

--- a/StormMemPoolFix/Base/MiMemPool.h
+++ b/StormMemPoolFix/Base/MiMemPool.h
@@ -109,7 +109,7 @@ namespace MiMemPool {
     void* AllocateSafe(size_t size) {
         if (g_cleanAllInProgress || g_insideUnsafePeriod.load()) {
             // 在不安全期间使用系统分配
-            void* sysPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader),
+            void* sysPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader) + 2,
                 MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
             if (!sysPtr) {
                 LogMessage("[MiMemPool] 不安全期间系统内存分配失败: %zu", size);
@@ -126,7 +126,7 @@ namespace MiMemPool {
         SafeExecutionGuard guard(g_inOperation, "MiMemPool::AllocateSafe");
         if (!guard.CanProceed()) {
             // 使用系统分配作为备选
-            void* sysPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader),
+            void* sysPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader) + 2,
                 MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
             if (!sysPtr) return nullptr;
 
@@ -165,7 +165,7 @@ namespace MiMemPool {
 
         if (!ptr) {
             LogMessage("[MiMemPool] 分配失败，使用系统备选: %zu", size);
-            void* sysPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader),
+            void* sysPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader) + 2,
                 MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
             if (!sysPtr) return nullptr;
 
@@ -231,7 +231,7 @@ namespace MiMemPool {
             }
 
             if (header->Magic == STORM_MAGIC &&
-                header->HeapPtr == SPECIAL_MARKER) {
+                header->HeapId == SPECIAL_MARKER) {
                 result = true;
             }
         }

--- a/StormMemPoolFix/Storm/StormHeapHook.cpp
+++ b/StormMemPoolFix/Storm/StormHeapHook.cpp
@@ -149,9 +149,7 @@ static size_t StormBlockGetTotalSize(const void* pBlock)
         // => StormAllocHeader
         const StormAllocHeader* ah = reinterpret_cast<const StormAllocHeader*>(pBlock);
         size_t total = ah->Size + sizeof(StormAllocHeader) + ah->AlignPadding;
-        // 如果 (ah->Flags & 0x1) => boundaryMagic, 可能还会多 2字节
-        // 不同版本Storm 里 boundaryMagic 不一定; 这里先演示不加
-        // if (ah->Flags & 0x1) total += 2; 
+        if (ah->Flags & 0x1) total += 2; // 尾部哨兵
         return total;
     }
 }

--- a/StormMemPoolFix/Storm/StormHook.cpp
+++ b/StormMemPoolFix/Storm/StormHook.cpp
@@ -831,11 +831,15 @@ void SetupCompatibleHeader(void* userPtr, size_t size) {
         StormAllocHeader* header = reinterpret_cast<StormAllocHeader*>(
             static_cast<char*>(userPtr) - sizeof(StormAllocHeader));
 
-        header->HeapPtr = SPECIAL_MARKER;  // 特殊标记
-        header->Size = static_cast<DWORD>(size);
+        header->Size = static_cast<WORD>(size + sizeof(StormAllocHeader) + 2);
         header->AlignPadding = 0;
-        header->Flags = 0x4;  // 标记为大块VirtualAlloc
+        header->Flags = 0x5;  // 大块VirtualAlloc + 尾部哨兵
+        header->HeapId = SPECIAL_MARKER;
         header->Magic = STORM_MAGIC;
+
+        // 写入尾部哨兵
+        WORD* tail = reinterpret_cast<WORD*>(static_cast<char*>(userPtr) + size);
+        *tail = 0x12B1;
     }
     __except (EXCEPTION_EXECUTE_HANDLER) {
         LogMessage("[ERROR] 设置兼容头失败: %p, 错误=0x%x", userPtr, GetExceptionCode());
@@ -861,7 +865,7 @@ bool IsOurBlock(void* ptr) {
         }
 
         return (header->Magic == STORM_MAGIC &&
-            header->HeapPtr == SPECIAL_MARKER);
+            header->HeapId == SPECIAL_MARKER);
     }
     __except (EXCEPTION_EXECUTE_HANDLER) {
         return false;
@@ -951,7 +955,7 @@ bool IsSpecialBlockAllocation(size_t size, const char* name, DWORD src_line) {
 // JassVM内存分配函数优化
 void* AllocateJassVMMemory(size_t size) {
     // 使用 VirtualAlloc 直接分配而非 TLSF
-    void* rawPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader),
+    void* rawPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader) + 2,
         MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
 
     if (!rawPtr) {
@@ -1419,7 +1423,7 @@ namespace MemPool {
     void* AllocateSafe(size_t size) {
         // 在不安全期间直接使用系统分配
         if (g_cleanAllInProgress || g_insideUnsafePeriod.load()) {
-            void* sysPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader),
+            void* sysPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader) + 2,
                 MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
             if (!sysPtr) {
                 LogMessage("[MemPool] 不安全期间系统内存分配失败: %zu", size);
@@ -1444,7 +1448,7 @@ namespace MemPool {
             LogMessage("[MemPool] Allocate: TLSF分配操作正在进行，回退到系统分配");
 
             // 使用系统分配作为备选
-            void* sysPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader),
+            void* sysPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader) + 2,
                 MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
             if (!sysPtr) return nullptr;
 
@@ -1552,7 +1556,7 @@ namespace MemPool {
                 StormAllocHeader* header = reinterpret_cast<StormAllocHeader*>(
                     static_cast<char*>(ptr) - sizeof(StormAllocHeader));
 
-                if (header->Magic == STORM_MAGIC && header->HeapPtr == SPECIAL_MARKER) {
+                if (header->Magic == STORM_MAGIC && header->HeapId == SPECIAL_MARKER) {
                     void* basePtr = static_cast<char*>(ptr) - sizeof(StormAllocHeader);
                     VirtualFree(basePtr, 0, MEM_RELEASE);
                     return;
@@ -1897,7 +1901,7 @@ namespace MemPool {
         }
 
         // 使用系统分配确保稳定性
-        void* rawPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader),
+        void* rawPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader) + 2,
             MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
         if (!rawPtr) {
             LogMessage("[MemPool] 无法分配稳定化块: %zu", size);
@@ -2237,7 +2241,7 @@ size_t __fastcall Hooked_Storm_MemAlloc(int ecx, int edx, size_t size, const cha
 
     if (useTLSF) {
         // 先尝试从缓存获取大块
-        void* cachedPtr = g_largeBlockCache.GetBlock(size + sizeof(StormAllocHeader));
+        void* cachedPtr = g_largeBlockCache.GetBlock(size + sizeof(StormAllocHeader) + 2);
         if (cachedPtr) {
             void* userPtr = static_cast<char*>(cachedPtr) + sizeof(StormAllocHeader);
             SetupCompatibleHeader(userPtr, size);
@@ -2263,7 +2267,7 @@ size_t __fastcall Hooked_Storm_MemAlloc(int ecx, int edx, size_t size, const cha
         }
 
         // 缓存未命中，使用 TLSF 分配
-        size_t totalSize = size + sizeof(StormAllocHeader);
+        size_t totalSize = size + sizeof(StormAllocHeader) + 2;
         void* rawPtr = MemPool::AllocateSafe(totalSize);
 
         if (!rawPtr) {
@@ -2511,7 +2515,7 @@ void* __fastcall Hooked_Storm_MemReAlloc(int ecx, int edx, void* oldPtr, size_t 
         void* newPtr = nullptr;
 
         __try {
-            newRawPtr = MemPool::ReallocSafe(oldInfo.rawPtr, newSize + sizeof(StormAllocHeader));
+            newRawPtr = MemPool::ReallocSafe(oldInfo.rawPtr, newSize + sizeof(StormAllocHeader) + 2);
             if (!newRawPtr) {
                 LogMessage("[Realloc] TLSF重分配失败, 大小=%zu", newSize);
                 return nullptr;
@@ -2628,7 +2632,7 @@ void* __fastcall Hooked_Storm_MemReAlloc(int ecx, int edx, void* oldPtr, size_t 
 
         __try {
             // 分配新的TLSF块
-            size_t totalSize = newSize + sizeof(StormAllocHeader);
+            size_t totalSize = newSize + sizeof(StormAllocHeader) + 2;
             newRawPtr = MemPool::AllocateSafe(totalSize);
             if (!newRawPtr) {
                 return s_origStormReAlloc(ecx, edx, oldPtr, newSize, name, src_line, flag);

--- a/StormMemPoolFix/Storm/StormHook.h
+++ b/StormMemPoolFix/Storm/StormHook.h
@@ -18,11 +18,11 @@
 // Storm结构体定义
 #pragma pack(push, 1)
 struct StormAllocHeader {
-    DWORD HeapPtr;      // 指向所属堆结构
-    DWORD Size;         // 用户数据区大小
-    BYTE  AlignPadding; // 对齐填充字节数
-    BYTE  Flags;        // 标志位: 0x1=魔数校验, 0x2=已释放, 0x4=大块VirtualAlloc, 0x8=特殊指针
-    WORD  Magic;        // 魔数 (0x6F6D)
+    WORD Size;          // Block size including header and tail
+    BYTE AlignPadding;  // 对齐填充字节数
+    BYTE Flags;         // 标志位: 0x1=尾部哨兵, 0x2=已释放, 0x4=大块VirtualAlloc, 0x8=特殊指针
+    WORD HeapId;        // 高16位堆标识或特殊标记
+    WORD Magic;         // 魔数 (0x6F6D)
 };
 #pragma pack(pop)
 
@@ -95,8 +95,8 @@ typedef void* (__fastcall* Storm_MemReAlloc_t)(int ecx, int edx, void* oldPtr, s
 typedef void(*StormHeap_CleanupAll_t)();
 
 // 常量定义
-constexpr DWORD STORM_MAGIC = 0x6F6D;        // Storm块头魔数 "mo"
-constexpr DWORD SPECIAL_MARKER = 0xC0DEFEED; // 特殊标记，表明是我们管理的块
+constexpr WORD  STORM_MAGIC = 0x6F6D;        // Storm块头魔数 "mo"
+constexpr WORD  SPECIAL_MARKER = 0xC0DE;    // 特殊标记，高位堆标识
 
 // 全局变量声明
 extern std::atomic<size_t> g_bigThreshold;      // 大块阈值


### PR DESCRIPTION
## Summary
- update StormAllocHeader layout to match actual Storm structure
- add tail sentinel and store high-word heap marker
- adjust memory allocations and sentinel checks

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_683fb29c009c8333a9a676c7f668a922