### PR TITLE
Fix Storm header alignment

### DIFF
--- a/StormMemPoolFix/Base/MemoryBackend.cpp
+++ b/StormMemPoolFix/Base/MemoryBackend.cpp
@@ -76,7 +76,7 @@ namespace MemoryPool {
         case MemBackendType::System:
         {
             // 使用系统分配 - 添加花括号创建作用域
-            void* sysPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader),
+            void* sysPtr = VirtualAlloc(NULL, size + sizeof(StormAllocHeader) + 2,
                 MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
             if (!sysPtr) return nullptr;
 
@@ -193,7 +193,9 @@ namespace MemoryPool {
 
                 if (!IsBadReadPtr(header, sizeof(StormAllocHeader)) &&
                     header->Magic == STORM_MAGIC) {
-                    oldSize = header->Size;
+                    size_t total = header->Size;
+                    oldSize = total - sizeof(StormAllocHeader) - header->AlignPadding;
+                    if (header->Flags & 0x1) oldSize -= 2;
                 }
             }
             catch (...) {

--- a/StormMemPoolFix/Base/MemorySafetyUtils.h
+++ b/StormMemPoolFix/Base/MemorySafetyUtils.h
@@ -103,19 +103,21 @@ public:
         }
 
         // 如果特殊标记
-        if (header->HeapPtr == SPECIAL_MARKER) {
+        if (header->HeapId == SPECIAL_MARKER) {
             return true;
         }
 
         // 验证Storm块一致性
         if (header->Size == 0 ||
-            header->Size > 0x1000000 || // 16MB是一个合理的上限
+            header->Size > 0x1000000 || // 合理的上限
             (header->Flags & 0x2)) { // 标记为已释放
             return false;
         }
 
-        // 检查用户区是否可访问
-        return !IsBadReadPtr(userPtr, header->Size);
+        size_t userSize = header->Size - sizeof(StormAllocHeader) - header->AlignPadding;
+        if (header->Flags & 0x1) userSize -= 2;
+
+        return !IsBadReadPtr(userPtr, userSize);
     }
 
     // 尝试获取块大小
@@ -136,7 +138,10 @@ public:
         }
 
         if (header->Magic == STORM_MAGIC) {
-            return header->Size;
+            size_t total = header->Size;
+            size_t user = total - sizeof(StormAllocHeader) - header->AlignPadding;
+            if (header->Flags & 0x1) user -= 2;
+            return user;
         }
 
         return 0;

--- a/StormMemPoolFix/Storm/StormHeapHook.cpp
+++ b/StormMemPoolFix/Storm/StormHeapHook.cpp
@@ -148,11 +148,7 @@ static size_t StormBlockGetTotalSize(const void* pBlock)
     {
         // => StormAllocHeader
         const StormAllocHeader* ah = reinterpret_cast<const StormAllocHeader*>(pBlock);
-        size_t total = ah->Size + sizeof(StormAllocHeader) + ah->AlignPadding;
-        // 如果 (ah->Flags & 0x1) => boundaryMagic, 可能还会多 2字节
-        // 不同版本Storm 里 boundaryMagic 不一定; 这里先演示不加
-        // if (ah->Flags & 0x1) total += 2; 
-        return total;
+        return ah->Size;
     }
 }
 

--- a/StormMemPoolFix/Storm/StormHook.h
+++ b/StormMemPoolFix/Storm/StormHook.h
@@ -18,11 +18,11 @@
 // Storm结构体定义
 #pragma pack(push, 1)
 struct StormAllocHeader {
-    DWORD HeapPtr;      // 指向所属堆结构
-    DWORD Size;         // 用户数据区大小
-    BYTE  AlignPadding; // 对齐填充字节数
-    BYTE  Flags;        // 标志位: 0x1=魔数校验, 0x2=已释放, 0x4=大块VirtualAlloc, 0x8=特殊指针
-    WORD  Magic;        // 魔数 (0x6F6D)
+    WORD Size;          // 用户数据大小(不含头部和尾部)
+    BYTE AlignPadding;  // 对齐填充字节数
+    BYTE Flags;         // 标志位: 0x1=尾部哨兵, 0x2=已释放, 0x4=大块VirtualAlloc, 0x8=特殊指针
+    WORD HeapId;        // 高16位堆标识或特殊标记
+    WORD Magic;         // 魔数 (0x6F6D)
 };
 #pragma pack(pop)
 
@@ -95,8 +95,8 @@ typedef void* (__fastcall* Storm_MemReAlloc_t)(int ecx, int edx, void* oldPtr, s
 typedef void(*StormHeap_CleanupAll_t)();
 
 // 常量定义
-constexpr DWORD STORM_MAGIC = 0x6F6D;        // Storm块头魔数 "mo"
-constexpr DWORD SPECIAL_MARKER = 0xC0DEFEED; // 特殊标记，表明是我们管理的块
+constexpr WORD  STORM_MAGIC = 0x6F6D;        // Storm块头魔数 "mo"
+constexpr WORD  SPECIAL_MARKER = 0xC0DE;    // 特殊标记，高位堆标识
 
 // 全局变量声明
 extern std::atomic<size_t> g_bigThreshold;      // 大块阈值


### PR DESCRIPTION
## Summary
- update StormAllocHeader layout to store total block size
- adjust sentinel offset and pointer checks to compute user length
- correct total size logic in StormBlockGetTotalSize

## Testing
- `cmake ../StormMemPoolFix` *(fails: cmake could not find requested files)*

------
https://chatgpt.com/codex/tasks/task_e_683fb29c009c8333a9a676c7f668a922